### PR TITLE
Miscellaneous fixes and improvements to https-everywhere-checker

### DIFF
--- a/coverage.checker.config
+++ b/coverage.checker.config
@@ -5,6 +5,7 @@
 rulesdir = src/chrome/content/rules
 check_coverage = true
 include_default_off = false
+skiplist = utils/ruleset-coverage-whitelist.txt
 
 [certificates]
 basedir = https-everywhere-checker/platform_certs

--- a/disable-broken-rulesets.checker.config
+++ b/disable-broken-rulesets.checker.config
@@ -15,7 +15,7 @@ enabled = true
 connect_timeout = 10
 read_timeout = 15
 redirect_depth = 10
-threads = 150
+threads = 40
 fetch_in_subprocess = false
 
 [log]

--- a/disable-broken-rulesets.checker.config
+++ b/disable-broken-rulesets.checker.config
@@ -2,7 +2,7 @@
 # that fail.
 [rulesets]
 rulesdir = src/chrome/content/rules
-check_coverage = true
+check_coverage = false
 auto_disable = true
 include_default_off = false
 

--- a/manual.checker.config
+++ b/manual.checker.config
@@ -21,7 +21,7 @@ fetch_in_subprocess = false
 
 [log]
 logfile = -
-loglevel = debug
+loglevel = info
 
 [thresholds]
 metric = markup

--- a/src/https_everywhere_checker/check_rules.py
+++ b/src/https_everywhere_checker/check_rules.py
@@ -116,9 +116,9 @@ class UrlComparisonThread(threading.Thread):
 			#(note this is not symmetric, we don't care if orig page is broken).
 			#We don't handle 1xx codes for now.
 			if plainRcode//100 == 2 and transformedRcode//100 != 2:
-				message = "Non-2xx HTTP code: %s (%d) => %s (%d) %s" % (
+				message = "Non-2xx HTTP code: %s (%d) => %s (%d)" % (
 					plainUrl, plainRcode, transformedUrl,
-					transformedRcode, task.ruleset.whatApplies(plainUrl))
+					transformedRcode)
 				logging.debug(message)
 				return message
 			
@@ -131,8 +131,8 @@ class UrlComparisonThread(threading.Thread):
 				logging.info("Big distance %0.4f: %s (%d) -> %s (%d). Rulefile: %s =====",
 					distance, plainUrl, len(plainPage), transformedUrl, len(transformedPage), ruleFname)
 		except Exception, e:
-			message = "Fetch error: %s => %s %s: %s" % (
-				plainUrl, transformedUrl, task.ruleset.whatApplies(plainUrl), e)
+			message = "Fetch error: %s => %s: %s" % (
+				plainUrl, transformedUrl, e)
 			logging.debug(message)
 			return message
 		finally:

--- a/src/https_everywhere_checker/check_rules.py
+++ b/src/https_everywhere_checker/check_rules.py
@@ -192,7 +192,7 @@ def cli():
 	loglevel = convertLoglevel(config.get("log", "loglevel"))
 	if logfile == "-":
 		logging.basicConfig(stream=sys.stderr, level=loglevel,
-			format="%(asctime)s %(levelname)s %(message)s [%(pathname)s:%(lineno)d]")
+			format="%(levelname)s %(message)s")
 	else:
 		logging.basicConfig(filename=logfile, level=loglevel,
 			format="%(asctime)s %(levelname)s %(message)s [%(pathname)s:%(lineno)d]")
@@ -327,7 +327,9 @@ def cli():
 						testedUrlPairCount += 1
 						testUrls.append(test.url)
 					else:
-						logging.debug("Skipping landing page %s", test.url)
+						# TODO: We should fetch the non-rewritten exclusion URLs to make
+						# sure they still exist.
+						logging.debug("Skipping excluded URL%s", test.url)
 				task = ComparisonTask(testUrls, fetcherPlain, fetcher, ruleset)
 				taskQueue.put(task)
 		taskQueue.join()

--- a/src/https_everywhere_checker/http_client.py
+++ b/src/https_everywhere_checker/http_client.py
@@ -307,6 +307,7 @@ class HTTPFetcher(object):
 			c.setopt(c.HEADERFUNCTION, headerBuf.write)
 			c.setopt(c.CONNECTTIMEOUT, options.connectTimeout)
 			c.setopt(c.COOKIEJAR, COOKIE_FILE_NAME)
+			c.setopt(c.COOKIEFILE, COOKIE_FILE_NAME)
 			c.setopt(c.TIMEOUT, options.readTimeout)
 			# Validation should not be disabled except for debugging
 			#c.setopt(c.SSL_VERIFYPEER, 0)

--- a/src/https_everywhere_checker/http_client.py
+++ b/src/https_everywhere_checker/http_client.py
@@ -6,8 +6,13 @@ import urlparse
 import cStringIO
 import regex
 import cPickle
+import tempfile
 import traceback
 import subprocess
+
+# We need a cookie jar because some sites (e.g. forums.aws.amazon.com) go into a
+# redirect loop without it.
+COOKIE_FILE_NAME = tempfile.mkstemp()[1]
 
 class CertificatePlatforms(object):
 	"""Maps platform names from rulesets to CA certificate sets"""
@@ -262,6 +267,7 @@ class HTTPFetcher(object):
 			c.setopt(c.WRITEFUNCTION, buf.write)
 			c.setopt(c.HEADERFUNCTION, headerBuf.write)
 			c.setopt(c.CONNECTTIMEOUT, options.connectTimeout)
+			c.setopt(c.COOKIEJAR, COOKIE_FILE_NAME)
 			c.setopt(c.TIMEOUT, options.readTimeout)
 			# Validation should not be disabled except for debugging
 			#c.setopt(c.SSL_VERIFYPEER, 0)

--- a/src/https_everywhere_checker/http_client.py
+++ b/src/https_everywhere_checker/http_client.py
@@ -332,9 +332,12 @@ class HTTPFetcher(object):
 			if httpCode == 0:
 				raise HTTPFetcherError("Pycurl fetch failed for '%s'" % newUrl)
 			elif httpCode in (301, 302, 307):
-				#'Location' should be present only once, so the dict won't hurt
-				headers = dict(self._headerRe.findall(headerStr))
-				location = headers.get('Location')
+				# Parse out the headers and extract location, case-insensitively.
+				# If there are multiple location headers, pick the last one.
+				headers = dict()
+				for k, v in self._headerRe.findall(headerStr):
+					headers[k.lower()] = v
+				location = headers.get('location')
 				if not location:
 					raise HTTPFetcherError("Redirect for '%s' missing Location" % newUrl)
 				

--- a/src/https_everywhere_checker/http_client.py
+++ b/src/https_everywhere_checker/http_client.py
@@ -331,7 +331,7 @@ class HTTPFetcher(object):
 			#shitty HTTP header parsing
 			if httpCode == 0:
 				raise HTTPFetcherError("Pycurl fetch failed for '%s'" % newUrl)
-			elif httpCode in (301, 302):
+			elif httpCode in (301, 302, 307):
 				#'Location' should be present only once, so the dict won't hurt
 				headers = dict(self._headerRe.findall(headerStr))
 				location = headers.get('Location')
@@ -360,9 +360,6 @@ class HTTPFetcher(object):
 				else:
 					newUrl = location
 			
-				if newUrl in seenUrls:
-					raise HTTPFetcherError("Cycle detected - URL already encountered: %s" % newUrl)
-				
 				continue #fetch redirected location
 				
 			return (httpCode, bufValue)

--- a/src/https_everywhere_checker/metrics.py
+++ b/src/https_everywhere_checker/metrics.py
@@ -100,9 +100,17 @@ class MarkupMetric(Metric):
 		#same for our purpose.
 		if len(s1) == 0 and len(s2) == 0:
 			return 0
+		if s1 == s2:
+			return 0
 		
 		doc1 = etree.parse(StringIO(s1), etree.HTMLParser())
 		doc2 = etree.parse(StringIO(s2), etree.HTMLParser())
+
+		# If we failed to parse either document, return max Levenshtein distance.
+		# Note this will happen for non-HTML documents like favicons.
+		# Identical documents should hit the equality check before parsing.
+		if not doc1 or not doc2:
+			return 1
 		
 		mapped1, mapped2 = self.mappedTrees(doc1.getroot(), doc2.getroot())
 		

--- a/src/https_everywhere_checker/rules.py
+++ b/src/https_everywhere_checker/rules.py
@@ -28,7 +28,7 @@ class Rule(object):
 		return self.fromRe.search(url) is not None
 	
 	def __repr__(self):
-		return "<Rule from '%s' to '%s'>" % (self.fromRe, self.toPattern)
+		return "<Rule from '%s' to '%s'>" % (self.fromRe.pattern, self.toPattern)
 	
 	def __str__(self):
 		return self.__repr__()
@@ -174,7 +174,7 @@ class Ruleset(object):
 		# them off that rule or exclusion.
 		problems = []
 		for test in self.tests:
-			applies = self._whatApplies(test.url)
+			applies = self.whatApplies(test.url)
 			if applies:
 				applies.tests.append(test)
 			else:
@@ -198,7 +198,7 @@ class Ruleset(object):
 					self.filename, actual_count, needed_count, exclusion))
 		return problems
 
-	def _whatApplies(self, url):
+	def whatApplies(self, url):
 		for exclusion in self.exclusions:
 			if exclusion.matches(url):
 				return exclusion

--- a/src/https_everywhere_checker/rules.py
+++ b/src/https_everywhere_checker/rules.py
@@ -183,7 +183,12 @@ class Ruleset(object):
 		# Next, make sure each rule or exclusion has sufficient tests.
 		for rule in self.rules:
 			needed_count = 1 + len(regex.findall("[+*?|]", rule.fromPattern))
+			# Don't treat the question mark in non-capturing groups as increasing the
+			# number of required tests.
 			needed_count = needed_count - len(regex.findall("\(\?:", rule.fromPattern))
+			# Don't treat escaped questions marks as increasing the number of required
+			# tests.
+			needed_count = needed_count - len(regex.findall("\\?", rule.fromPattern))
 			actual_count = len(rule.tests)
 			if actual_count < needed_count:
 				problems.append("%s: Not enough tests (%d vs %s) for %s" % (
@@ -192,6 +197,7 @@ class Ruleset(object):
 		for exclusion in self.exclusions:
 			needed_count = 1 + len(regex.findall("[+*?|]", exclusion.exclusionPattern))
 			needed_count = needed_count - len(regex.findall("\(\?:", exclusion.exclusionPattern))
+			needed_count = needed_count - len(regex.findall("\\?", rule.fromPattern))
 			actual_count = len(exclusion.tests)
 			if actual_count < needed_count:
 				problems.append("%s: Not enough tests (%d vs %s) for %s" % (


### PR DESCRIPTION
Introduce a skipfile with hashes of files to optionally ignore.
Keep track of and send cookies to avoid loops.
Handle non-HTML responses (like favicon.ico).
Clearer logging.